### PR TITLE
회원가입 사용자 정보 validation 추가

### DIFF
--- a/src/api/validation/users.ts
+++ b/src/api/validation/users.ts
@@ -8,6 +8,7 @@ import {
   USER_PW_MIN_LENGTH,
 } from '../../constants/users';
 import ErrorResponse from '../../utils/error-response';
+import { REG_ID, REG_PW } from '../../utils/validation';
 
 export const userTestValidation = (req: Request, _res: Response, next: NextFunction): void => {
   const schema = Joi.object({
@@ -35,9 +36,11 @@ export const userCreateValidation = (req: Request, _res: Response, next: NextFun
       .max(USER_ID_MAX_LENGTH)
       .required()
       .empty('')
+      .regex(REG_ID)
       .messages({
         'string.min': `아이디는 ${USER_ID_MIN_LENGTH}자 이상 입력해야 합니다`,
         'string.max': `아이디는 ${USER_ID_MAX_LENGTH}자를 넘길 수 없습니다`,
+        'string.pattern.base': `아이디는 ${USER_ID_MIN_LENGTH} ~ ${USER_ID_MAX_LENGTH}자 사이면서 영대소문자, 숫자만 사용할 수 있고 영문자로 시작해야 합니다.`,
         'any.required': `아이디를 입력해주세요`,
       }),
     password: Joi.string()
@@ -45,9 +48,11 @@ export const userCreateValidation = (req: Request, _res: Response, next: NextFun
       .max(USER_PW_MAX_LENGTH)
       .required()
       .empty('')
+      .regex(REG_PW)
       .messages({
         'string.min': `비밀번호는 ${USER_PW_MIN_LENGTH}자 이상 입력해야 합니다`,
         'string.max': `비밀번호는 ${USER_PW_MAX_LENGTH}자를 넘길 수 없습니다`,
+        'string.pattern.base': `비밀번호는 ${USER_PW_MIN_LENGTH} ~ ${USER_PW_MAX_LENGTH}자 사이면서 영대소문자, 숫자, 특수문자 중 2개 이상 조합이어야 합니다`,
         'any.required': `비밀번호를 입력해주세요`,
       }),
   });

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -1,5 +1,5 @@
-export const USER_ID_MIN_LENGTH = 3;
+export const USER_ID_MIN_LENGTH = 4;
 export const USER_ID_MAX_LENGTH = 30;
 
-export const USER_PW_MIN_LENGTH = 4;
+export const USER_PW_MIN_LENGTH = 10;
 export const USER_PW_MAX_LENGTH = 35;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,26 @@
+import {
+  USER_ID_MAX_LENGTH,
+  USER_ID_MIN_LENGTH,
+  USER_PW_MAX_LENGTH,
+  USER_PW_MIN_LENGTH,
+} from '../constants/users';
+
+export const REG_ID = new RegExp(
+  `^[a-zA-Z]+[a-zA-Z0-9]{${USER_ID_MIN_LENGTH},${USER_ID_MAX_LENGTH}}$`,
+);
+
+export const REG_PW = new RegExp(
+  [
+    '^',
+    `(?=.*[A-Z])(?=.*[a-z])([^\\s]){${USER_PW_MIN_LENGTH},${USER_PW_MAX_LENGTH}}|`,
+    `(?=.*[A-Z])(?=.*[0-9])([^\\s]){${USER_PW_MIN_LENGTH},${USER_PW_MAX_LENGTH}}|`,
+    `(?=.*[A-Z])(?=.*[<>{}|;:.,~!?@#$%^=&*\\"\\\\/])([^\\s]){${USER_PW_MIN_LENGTH},${USER_PW_MAX_LENGTH}}|`,
+    `(?=.*[a-z])(?=.*[0-9])([^\\s]){${USER_PW_MIN_LENGTH},${USER_PW_MAX_LENGTH}}|`,
+    `(?=.*[a-z])(?=.*[<>{}|;:.,~!?@#$%^=&*\\"\\/])([^\\s]){${USER_PW_MIN_LENGTH},${USER_PW_MAX_LENGTH}}|`,
+    `(?=.*[0-9])(?=.*[<>{}|;:.,~!?@#$%^=&*\\"\\\\/])([^\\s]){${USER_PW_MIN_LENGTH},${USER_PW_MAX_LENGTH}}`,
+    '$',
+  ].reduce((acc, cur) => acc + cur, ''),
+);
+
+export const idValidator = (id: string): boolean => REG_ID.test(id);
+export const pwValidator = (pw: string): boolean => REG_PW.test(pw);

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,0 +1,75 @@
+import { idValidator, pwValidator } from '../../src/utils/validation';
+
+describe('validation utils 테스트', () => {
+  describe('idValidator() 함수 테스트', () => {
+    it(`공백문자열은 거짓을 반환해야 합니다.`, () => {
+      expect(idValidator('')).toBe(false);
+    });
+    it(`4자보다 길이가 짧을 경우 거짓을 반환해야 합니다.`, () => {
+      expect(idValidator('1')).toBe(false);
+    });
+    it(`30자보다 길이가 길 경우 거짓을 반환해야 합니다.`, () => {
+      const MAX_LENGTH = 30;
+      expect(idValidator('1'.repeat(MAX_LENGTH + 1))).toBe(false);
+    });
+    it(`특수문자가 포함될 경우 거짓을 반환해야 합니다.`, () => {
+      expect(idValidator('ABCabc!@#')).toBe(false);
+    });
+    it(`숫자로 시작할 경우 거짓을 반환해야 합니다.`, () => {
+      expect(idValidator('123ABC')).toBe(false);
+    });
+    it('4 ~ 30자 사이의 영문자로 시작하는 영대소문자 + 숫자 조합은 참을 반환해야 합니다.', () => {
+      expect(idValidator('ABCabc123')).toBe(true);
+      expect(idValidator('ABC123')).toBe(true);
+      expect(idValidator('a321bc')).toBe(true);
+    });
+    it('4 ~ 30자 사이의 영문자로 시작하는 영대문자 + 영소문자 조합은 참을 반환해야 합니다.', () => {
+      expect(idValidator('ABCabc')).toBe(true);
+      expect(idValidator('ABCbbb')).toBe(true);
+      expect(idValidator('aCCCaaab')).toBe(true);
+    });
+  });
+
+  describe('pwValidator() 함수 테스트', () => {
+    it(`공백문자열은 거짓을 반환해야 합니다.`, () => {
+      expect(pwValidator('')).toBe(false);
+    });
+    it(`10자보다 길이가 짧을 경우 거짓을 반환해야 합니다.`, () => {
+      expect(pwValidator('1')).toBe(false);
+    });
+    it(`35자보다 길이가 길 경우 거짓을 반환해야 합니다.`, () => {
+      const MAX_LENGTH = 35;
+      expect(pwValidator('1'.repeat(MAX_LENGTH + 1))).toBe(false);
+    });
+    it('10 ~ 35자 사이의 영대문자 + 영소문자 조합은 참을 반환해야 합니다. ', () => {
+      expect(pwValidator('ABCabcABCa')).toBe(true);
+      expect(pwValidator('abAbabABab')).toBe(true);
+      expect(pwValidator('aaaBBBaaaB')).toBe(true);
+    });
+    it('10 ~ 35자 사이의 영대문자 + 숫자 조합은 참을 반환해야 합니다. ', () => {
+      expect(pwValidator('ABC123ABC123')).toBe(true);
+      expect(pwValidator('AB12AB12ABB')).toBe(true);
+      expect(pwValidator('BBB111BBB111')).toBe(true);
+    });
+    it('10 ~ 35자 사이의 영대문자 + 특수문자 조합은 참을 반환해야 합니다. ', () => {
+      expect(pwValidator('ABC!@$ABC!@$')).toBe(true);
+      expect(pwValidator('AB!@AB!@AB!')).toBe(true);
+      expect(pwValidator('BBB!@$BBB!@$')).toBe(true);
+    });
+    it('10 ~ 35자 사이의 영소문자 + 숫자 조합은 참을 반환해야 합니다. ', () => {
+      expect(pwValidator('abc123abc123')).toBe(true);
+      expect(pwValidator('ab12ab12abb')).toBe(true);
+      expect(pwValidator('bbb111bbb111')).toBe(true);
+    });
+    it('10 ~ 35자 사이의 영소문자 + 특수문자 조합은 참을 반환해야 합니다. ', () => {
+      expect(pwValidator('abc!@$abc!@$')).toBe(true);
+      expect(pwValidator('ab!@ab!@ab!')).toBe(true);
+      expect(pwValidator('bbb!@$bbb!@$')).toBe(true);
+    });
+    it('10 ~ 35자 사이의 숫자 + 특수문자 조합은 참을 반환해야 합니다. ', () => {
+      expect(pwValidator('123!@$123!@$')).toBe(true);
+      expect(pwValidator('12!@12!@12!')).toBe(true);
+      expect(pwValidator('222!@$222!@$')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

회원가입을 위한 사용자 정보 validation 패턴 검사를 추가했습니다.

## 이슈 번호

- closes #6 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

- id/pw에 대한 정책 결정
  - id : 아이디는 4 ~ 30자 사이면서 영대소문자, 숫자만 사용할 수 있고 영문자로 시작해야 합니다.
  - pw : 비밀번호는 10 ~ 35자 사이면서 영대소문자, 숫자, 특수문자 중 2개 이상 조합이어야 합니다
- 정책 결정에 따라 validation util 구현 및 테스트 코드 작성
- 회원가입 API validation layer에서 pattern 검사 추가

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- validation util에 대한 테스트를 통해서 id/password 검증 로직에 대해서 테스트 하려고 했습니다. 혹여 빠진 테스트 케이스가 있는 지 확인해주세요.
- id/pw 정책에 대해서 추가적인 제안/의견이 있으시다면 편하게 말씀해주세요~.
