### PR TITLE
서비스 관련 API 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 
 import auth from './routes/auth';
+import services from './routes/services';
 import users from './routes/users';
 
 const router = Router();
 
 router.use('/auth', auth);
 router.use('/users', users);
+router.use('/services', services);
 
 export default router;

--- a/src/api/middlewares/validate-token.ts
+++ b/src/api/middlewares/validate-token.ts
@@ -1,0 +1,29 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { commonError } from '../../constants/error';
+import ErrorResponse from '../../utils/error-response';
+import { checkTokenExpiration, getAccessToken, getRefreshToken } from '../../utils/jwt';
+
+const validateToken = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const accessToken = getAccessToken(req.headers.authorization);
+    const refreshToken = getRefreshToken(req.cookies);
+
+    if (!accessToken || !refreshToken) {
+      throw new ErrorResponse(commonError.unauthorized);
+    }
+
+    const isTokenExpired = await checkTokenExpiration(accessToken);
+
+    if (isTokenExpired) {
+      res.redirect(303, '/api/auth?redirect=true');
+      return;
+    }
+
+    next();
+  } catch (e) {
+    next(e);
+  }
+};
+
+export default validateToken;

--- a/src/api/middlewares/validate-token.ts
+++ b/src/api/middlewares/validate-token.ts
@@ -1,8 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
+import { Container } from 'typedi';
 
 import { commonError } from '../../constants/error';
+import JwtHelper from '../../helpers/jwt';
 import ErrorResponse from '../../utils/error-response';
-import { checkTokenExpiration, getAccessToken, getRefreshToken } from '../../utils/jwt';
+import { getAccessToken, getRefreshToken } from '../../utils/jwt';
 
 const validateToken = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
@@ -13,7 +15,8 @@ const validateToken = async (req: Request, res: Response, next: NextFunction): P
       throw new ErrorResponse(commonError.unauthorized);
     }
 
-    const isTokenExpired = await checkTokenExpiration(accessToken);
+    const jwtHelper = Container.get<JwtHelper>('jwtHelper');
+    const isTokenExpired = await jwtHelper.checkTokenExpiration(accessToken);
 
     if (isTokenExpired) {
       res.redirect(303, '/api/auth?redirect=true');

--- a/src/api/routes/services/index.ts
+++ b/src/api/routes/services/index.ts
@@ -5,6 +5,7 @@ import validateToken from '../../middlewares/validate-token';
 import { createServiceValidation, serviceIdValidation } from '../../validation/services';
 import {
   handleCreateService,
+  handleDeleteService,
   handleGetService,
   handleGetUserServices,
 } from './services.controller';
@@ -14,5 +15,6 @@ const router = Router();
 router.post('/', validateToken, createServiceValidation, handleCreateService);
 router.get('/id/:id', serviceIdValidation, handleGetService);
 router.get('/user', validateToken, handleGetUserServices);
+router.delete('/id/:id', validateToken, serviceIdValidation, handleDeleteService);
 
 export default router;

--- a/src/api/routes/services/index.ts
+++ b/src/api/routes/services/index.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+import { getServiceValidation } from '../../validation/services';
+import { handleGetService } from './services.controller';
+
+const router = Router();
+
+router.get('/:id', getServiceValidation, handleGetService);
+
+export default router;

--- a/src/api/routes/services/index.ts
+++ b/src/api/routes/services/index.ts
@@ -13,7 +13,7 @@ import {
 const router = Router();
 
 router.post('/', validateToken, createServiceValidation, handleCreateService);
-router.get('/id/:id', serviceIdValidation, handleGetService);
+router.get('/id/:id', validateToken, serviceIdValidation, handleGetService);
 router.get('/user', validateToken, handleGetUserServices);
 router.delete('/id/:id', validateToken, serviceIdValidation, handleDeleteService);
 

--- a/src/api/routes/services/index.ts
+++ b/src/api/routes/services/index.ts
@@ -2,11 +2,16 @@
 import { Router } from 'express';
 
 import validateToken from '../../middlewares/validate-token';
-import { serviceIdValidation } from '../../validation/services';
-import { handleGetService, handleGetUserServices } from './services.controller';
+import { createServiceValidation, serviceIdValidation } from '../../validation/services';
+import {
+  handleCreateService,
+  handleGetService,
+  handleGetUserServices,
+} from './services.controller';
 
 const router = Router();
 
+router.post('/', validateToken, createServiceValidation, handleCreateService);
 router.get('/id/:id', serviceIdValidation, handleGetService);
 router.get('/user', validateToken, handleGetUserServices);
 

--- a/src/api/routes/services/index.ts
+++ b/src/api/routes/services/index.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 
+import validateToken from '../../middlewares/validate-token';
 import { getServiceValidation } from '../../validation/services';
-import { handleGetService } from './services.controller';
+import { handleGetService, handleGetUserServices } from './services.controller';
 
 const router = Router();
 
-router.get('/:id', getServiceValidation, handleGetService);
+router.get('/id/:id', getServiceValidation, handleGetService);
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+router.get('/user', validateToken, handleGetUserServices);
 
 export default router;

--- a/src/api/routes/services/index.ts
+++ b/src/api/routes/services/index.ts
@@ -1,13 +1,13 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 import { Router } from 'express';
 
 import validateToken from '../../middlewares/validate-token';
-import { getServiceValidation } from '../../validation/services';
+import { serviceIdValidation } from '../../validation/services';
 import { handleGetService, handleGetUserServices } from './services.controller';
 
 const router = Router();
 
-router.get('/id/:id', getServiceValidation, handleGetService);
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
+router.get('/id/:id', serviceIdValidation, handleGetService);
 router.get('/user', validateToken, handleGetUserServices);
 
 export default router;

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import { Container } from 'typedi';
 
 import ServiceService from '../../../services/service';
+import { getAccessToken, getUIDFromToken } from '../../../utils/jwt';
 
 export const handleGetService = async (
   req: Request,
@@ -15,6 +16,23 @@ export const handleGetService = async (
     const service = await serviceServiceInstance.getService(Number(id));
 
     res.json(service);
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const handleGetUserServices = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const uid = getUIDFromToken(getAccessToken(req.headers.authorization));
+
+    const serviceServiceInstance = Container.get(ServiceService);
+    const result = await serviceServiceInstance.getAllServiceOfUser(uid);
+
+    res.json(result);
   } catch (e) {
     next(e);
   }

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -13,8 +13,13 @@ export const handleGetService = async (
   try {
     const { id } = req.params;
 
+    const jwtHelper = Container.get<JwtHelper>('jwtHelper');
     const serviceServiceInstance = Container.get(ServiceService);
-    const service = await serviceServiceInstance.getService(Number(id));
+
+    const accessToken = getAccessToken(req.headers.authorization);
+    const { uid } = jwtHelper.decodeAccessToken(accessToken);
+
+    const service = await serviceServiceInstance.getService(uid, Number(id));
 
     res.json(service);
   } catch (e) {
@@ -34,7 +39,7 @@ export const handleGetUserServices = async (
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid } = jwtHelper.decodeAccessToken(accessToken);
 
-    const result = await serviceServiceInstance.getAllServiceOfUser(uid);
+    const result = await serviceServiceInstance.getAllServiceAndCountOfUser(uid);
 
     res.json(result);
   } catch (e) {

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -54,3 +54,21 @@ export const handleCreateService = async (
     next(e);
   }
 };
+
+export const handleDeleteService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const uid = getUIDFromToken(getAccessToken(req.headers.authorization));
+
+    const serviceServiceInstance = Container.get(ServiceService);
+    await serviceServiceInstance.deleteService(uid, Number(id));
+
+    res.status(200).json({ result: 'service delete success' });
+  } catch (e) {
+    next(e);
+  }
+};

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -15,7 +15,7 @@ export const handleGetService = async (
     const serviceServiceInstance = Container.get(ServiceService);
     const service = await serviceServiceInstance.getService(Number(id));
 
-    res.json(service);
+    res.status(200).json(service);
   } catch (e) {
     next(e);
   }
@@ -32,7 +32,7 @@ export const handleGetUserServices = async (
     const serviceServiceInstance = Container.get(ServiceService);
     const result = await serviceServiceInstance.getAllServiceOfUser(uid);
 
-    res.json(result);
+    res.status(200).json(result);
   } catch (e) {
     next(e);
   }

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -1,0 +1,21 @@
+import { NextFunction, Request, Response } from 'express';
+import { Container } from 'typedi';
+
+import ServiceService from '../../../services/service';
+
+export const handleGetService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+
+    const serviceServiceInstance = Container.get(ServiceService);
+    const service = await serviceServiceInstance.getService(Number(id));
+
+    res.json(service);
+  } catch (e) {
+    next(e);
+  }
+};

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -1,8 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
 import { Container } from 'typedi';
 
+import JwtHelper from '../../../helpers/jwt';
 import ServiceService from '../../../services/service';
-import { getAccessToken, getUIDFromToken } from '../../../utils/jwt';
+import { getAccessToken } from '../../../utils/jwt';
 
 export const handleGetService = async (
   req: Request,
@@ -27,9 +28,12 @@ export const handleGetUserServices = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const uid = getUIDFromToken(getAccessToken(req.headers.authorization));
-
+    const jwtHelper = Container.get<JwtHelper>('jwtHelper');
     const serviceServiceInstance = Container.get(ServiceService);
+
+    const accessToken = getAccessToken(req.headers.authorization);
+    const { uid } = jwtHelper.decodeAccessToken(accessToken);
+
     const result = await serviceServiceInstance.getAllServiceOfUser(uid);
 
     res.json(result);
@@ -44,9 +48,12 @@ export const handleCreateService = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const uid = getUIDFromToken(getAccessToken(req.headers.authorization));
-
+    const jwtHelper = Container.get<JwtHelper>('jwtHelper');
     const serviceServiceInstance = Container.get(ServiceService);
+
+    const accessToken = getAccessToken(req.headers.authorization);
+    const { uid } = jwtHelper.decodeAccessToken(accessToken);
+
     const result = await serviceServiceInstance.createService(uid, req.body);
 
     res.json(result);
@@ -62,9 +69,13 @@ export const handleDeleteService = async (
 ): Promise<void> => {
   try {
     const { id } = req.params;
-    const uid = getUIDFromToken(getAccessToken(req.headers.authorization));
 
+    const jwtHelper = Container.get<JwtHelper>('jwtHelper');
     const serviceServiceInstance = Container.get(ServiceService);
+
+    const accessToken = getAccessToken(req.headers.authorization);
+    const { uid } = jwtHelper.decodeAccessToken(accessToken);
+
     await serviceServiceInstance.deleteService(uid, Number(id));
 
     res.status(204).end();

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -37,3 +37,20 @@ export const handleGetUserServices = async (
     next(e);
   }
 };
+
+export const handleCreateService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const uid = getUIDFromToken(getAccessToken(req.headers.authorization));
+
+    const serviceServiceInstance = Container.get(ServiceService);
+    const result = await serviceServiceInstance.createService(uid, req.body);
+
+    res.status(200).json(result);
+  } catch (e) {
+    next(e);
+  }
+};

--- a/src/api/routes/services/services.controller.ts
+++ b/src/api/routes/services/services.controller.ts
@@ -15,7 +15,7 @@ export const handleGetService = async (
     const serviceServiceInstance = Container.get(ServiceService);
     const service = await serviceServiceInstance.getService(Number(id));
 
-    res.status(200).json(service);
+    res.json(service);
   } catch (e) {
     next(e);
   }
@@ -32,7 +32,7 @@ export const handleGetUserServices = async (
     const serviceServiceInstance = Container.get(ServiceService);
     const result = await serviceServiceInstance.getAllServiceOfUser(uid);
 
-    res.status(200).json(result);
+    res.json(result);
   } catch (e) {
     next(e);
   }
@@ -49,7 +49,7 @@ export const handleCreateService = async (
     const serviceServiceInstance = Container.get(ServiceService);
     const result = await serviceServiceInstance.createService(uid, req.body);
 
-    res.status(200).json(result);
+    res.json(result);
   } catch (e) {
     next(e);
   }
@@ -67,7 +67,7 @@ export const handleDeleteService = async (
     const serviceServiceInstance = Container.get(ServiceService);
     await serviceServiceInstance.deleteService(uid, Number(id));
 
-    res.status(200).json({ result: 'service delete success' });
+    res.status(204).end();
   } catch (e) {
     next(e);
   }

--- a/src/api/validation/services.ts
+++ b/src/api/validation/services.ts
@@ -3,7 +3,7 @@ import Joi from 'joi';
 
 import ErrorResponse from '../../utils/error-response';
 
-export const getServiceValidation = (req: Request, _res: Response, next: NextFunction): void => {
+export const serviceIdValidation = (req: Request, _res: Response, next: NextFunction): void => {
   const schema = Joi.object({
     id: Joi.number().required().messages({
       'any.required': '서비스 ID를 입력해주세요',

--- a/src/api/validation/services.ts
+++ b/src/api/validation/services.ts
@@ -21,3 +21,24 @@ export const serviceIdValidation = (req: Request, _res: Response, next: NextFunc
 
   next();
 };
+
+export const createServiceValidation = (req: Request, _res: Response, next: NextFunction): void => {
+  const schema = Joi.object({
+    name: Joi.string().required().messages({
+      'any.required': '서비스 이름을 입력해주세요',
+    }),
+    description: Joi.string(),
+    domain: Joi.string(),
+  });
+
+  const validationResult = schema.validate(req.body);
+
+  if (validationResult.error) {
+    throw new ErrorResponse({
+      statusCode: 400,
+      message: validationResult.error.message,
+    });
+  }
+
+  next();
+};

--- a/src/api/validation/services.ts
+++ b/src/api/validation/services.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import Joi from 'joi';
+
+import ErrorResponse from '../../utils/error-response';
+
+export const getServiceValidation = (req: Request, _res: Response, next: NextFunction): void => {
+  const schema = Joi.object({
+    id: Joi.number().required().messages({
+      'any.required': '서비스 ID를 입력해주세요',
+    }),
+  });
+
+  const validationResult = schema.validate(req.params);
+
+  if (validationResult.error) {
+    throw new ErrorResponse({
+      statusCode: 400,
+      message: validationResult.error.message,
+    });
+  }
+
+  next();
+};

--- a/src/constants/error.ts
+++ b/src/constants/error.ts
@@ -45,13 +45,6 @@ export const commonError = {
   },
 };
 
-export const authError = {
-  invalidToken: {
-    statusCode: 500,
-    message: 'Invalid token',
-  },
-};
-
 export const themeError = {
   needDefaultTheme: {
     statusCode: 500,

--- a/src/constants/error.ts
+++ b/src/constants/error.ts
@@ -51,3 +51,10 @@ export const authError = {
     message: 'Invalid token',
   },
 };
+
+export const themeError = {
+  needDefaultTheme: {
+    statusCode: 500,
+    message: 'Should create default theme',
+  },
+};

--- a/src/constants/error.ts
+++ b/src/constants/error.ts
@@ -44,3 +44,10 @@ export const commonError = {
     message: 'Invalid state',
   },
 };
+
+export const authError = {
+  invalidToken: {
+    statusCode: 500,
+    message: 'Invalid token',
+  },
+};

--- a/src/entity/service.ts
+++ b/src/entity/service.ts
@@ -18,7 +18,7 @@ class ServiceEntity {
   @Column('varchar', { length: 45 })
   name: string;
 
-  @Column('char', { length: 20 })
+  @Column('char', { length: 20, unique: true })
   clientId: string;
 
   @Column('varchar', { length: 100, nullable: true })

--- a/src/entity/service.ts
+++ b/src/entity/service.ts
@@ -18,7 +18,7 @@ class ServiceEntity {
   @Column('varchar', { length: 45 })
   name: string;
 
-  @Column('char', { length: 20, unique: true })
+  @Column('char', { length: 36, unique: true })
   clientId: string;
 
   @Column('varchar', { length: 100, nullable: true })

--- a/src/entity/theme.ts
+++ b/src/entity/theme.ts
@@ -5,7 +5,7 @@ class ThemeEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column('varchar', { length: 20 })
+  @Column('varchar', { length: 20, unique: true })
   name: string;
 }
 

--- a/src/helpers/jwt.ts
+++ b/src/helpers/jwt.ts
@@ -1,4 +1,4 @@
-import jwt, { Algorithm, JwtPayload, SignOptions } from 'jsonwebtoken';
+import jwt, { Algorithm, JwtPayload, SignOptions, VerifyErrors } from 'jsonwebtoken';
 
 import { ACCESS_TOKEN_SUBJECT, REFRESH_TOKEN_SUBJECT } from '../constants/auth';
 
@@ -84,6 +84,18 @@ class JwtHelper {
   getRefreshExpiresInMs(): number {
     const expireMs = 1000 * this.refreshExpiresInSeconds;
     return expireMs;
+  }
+
+  checkTokenExpiration(token: string): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      jwt.verify(token, this.secret, (err: VerifyErrors | null) => {
+        if (err) {
+          if (err.name === 'TokenExpiredError') resolve(true);
+          else reject(err);
+        }
+        resolve(false);
+      });
+    });
   }
 }
 

--- a/src/loaders/connect.ts
+++ b/src/loaders/connect.ts
@@ -5,6 +5,7 @@ import { Container } from 'typeorm-typedi-extensions';
 const connect = async (): Promise<{ connection: Connection }> => {
   useContainer(Container);
   const connection = await createConnection();
+  await connection.synchronize();
 
   typedi.Container.set('connection', connection);
 

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -1,6 +1,10 @@
 import { EntityRepository, Repository } from 'typeorm';
 
 import ServiceEntity from '../entity/service';
+import ThemeEntity from '../entity/theme';
+import UserEntity from '../entity/user';
+import { ServiceBasicInfo } from '../types/service';
+import { createClientId } from '../utils/service';
 
 @EntityRepository(ServiceEntity)
 class ServiceRepository extends Repository<ServiceEntity> {
@@ -18,6 +22,26 @@ class ServiceRepository extends Repository<ServiceEntity> {
       relations: ['theme'],
     });
     return serviceListAndCount;
+  }
+
+  async createService(
+    serviceInfo: ServiceBasicInfo,
+    theme: ThemeEntity,
+    user: UserEntity,
+  ): Promise<ServiceEntity> {
+    const { name, description, domain } = serviceInfo;
+
+    const newService = new ServiceEntity();
+    newService.clientId = createClientId();
+    newService.name = name;
+    if (description) newService.description = description;
+    if (domain) newService.domain = domain;
+    newService.theme = theme;
+    newService.user = user;
+
+    const createdService = await this.save(newService);
+
+    return createdService;
   }
 }
 

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -4,7 +4,7 @@ import ServiceEntity from '../entity/service';
 import ThemeEntity from '../entity/theme';
 import UserEntity from '../entity/user';
 import { ServiceBasicInfo } from '../types/service';
-import { createClientId } from '../utils/service';
+import { uuidv4 } from '../utils/service';
 
 @EntityRepository(ServiceEntity)
 class ServiceRepository extends Repository<ServiceEntity> {
@@ -32,7 +32,7 @@ class ServiceRepository extends Repository<ServiceEntity> {
     const { name, description, domain } = serviceInfo;
 
     const newService = new ServiceEntity();
-    newService.clientId = createClientId();
+    newService.clientId = uuidv4();
     newService.name = name;
     if (description) newService.description = description;
     if (domain) newService.domain = domain;

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -31,14 +31,14 @@ class ServiceRepository extends Repository<ServiceEntity> {
   ): Promise<ServiceEntity> {
     const { name, description, domain } = serviceInfo;
 
-    const newService = new ServiceEntity();
-    newService.clientId = uuidv4();
-    newService.name = name;
-    if (description) newService.description = description;
-    if (domain) newService.domain = domain;
-    newService.theme = theme;
-    newService.user = user;
-
+    const newService = this.create({
+      clientId: uuidv4(),
+      name,
+      description,
+      domain,
+      theme,
+      user,
+    });
     const createdService = await this.save(newService);
 
     return createdService;

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -1,0 +1,13 @@
+import { EntityRepository, Repository } from 'typeorm';
+
+import ServiceEntity from '../entity/service';
+
+@EntityRepository(ServiceEntity)
+class ServiceRepository extends Repository<ServiceEntity> {
+  async findByServiceId(id: number): Promise<ServiceEntity | undefined> {
+    const service = await this.findOne({ where: { id } });
+    return service;
+  }
+}
+
+export default ServiceRepository;

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -8,6 +8,11 @@ class ServiceRepository extends Repository<ServiceEntity> {
     const service = await this.findOne({ where: { id } });
     return service;
   }
+
+  async findByUserId(userId: string): Promise<[ServiceEntity[], number]> {
+    const serviceListAndCount = await this.findAndCount({ where: { user: userId } });
+    return serviceListAndCount;
+  }
 }
 
 export default ServiceRepository;

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -16,7 +16,7 @@ class ServiceRepository extends Repository<ServiceEntity> {
     return service;
   }
 
-  async findByUserId(userId: string): Promise<[ServiceEntity[], number]> {
+  async findAndCountByUserId(userId: string): Promise<[ServiceEntity[], number]> {
     const serviceListAndCount = await this.findAndCount({
       where: { user: userId },
       relations: ['theme'],

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -5,12 +5,18 @@ import ServiceEntity from '../entity/service';
 @EntityRepository(ServiceEntity)
 class ServiceRepository extends Repository<ServiceEntity> {
   async findByServiceId(id: number): Promise<ServiceEntity | undefined> {
-    const service = await this.findOne({ where: { id } });
+    const service = await this.findOne({
+      where: { id },
+      relations: ['theme', 'user'],
+    });
     return service;
   }
 
   async findByUserId(userId: string): Promise<[ServiceEntity[], number]> {
-    const serviceListAndCount = await this.findAndCount({ where: { user: userId } });
+    const serviceListAndCount = await this.findAndCount({
+      where: { user: userId },
+      relations: ['theme'],
+    });
     return serviceListAndCount;
   }
 }

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -43,6 +43,10 @@ class ServiceRepository extends Repository<ServiceEntity> {
 
     return createdService;
   }
+
+  async deleteService(service: ServiceEntity): Promise<void> {
+    await this.remove(service);
+  }
 }
 
 export default ServiceRepository;

--- a/src/repositories/service.ts
+++ b/src/repositories/service.ts
@@ -9,17 +9,19 @@ import { uuidv4 } from '../utils/service';
 @EntityRepository(ServiceEntity)
 class ServiceRepository extends Repository<ServiceEntity> {
   async findByServiceId(id: number): Promise<ServiceEntity | undefined> {
-    const service = await this.findOne({
-      where: { id },
-      relations: ['theme', 'user'],
-    });
+    const service = await this.createQueryBuilder('service')
+      .where('service.id = :id', { id })
+      .leftJoinAndSelect('service.theme', 'theme')
+      .leftJoin('service.user', 'user')
+      .addSelect(['user.uid'])
+      .getOne();
     return service;
   }
 
   async findAndCountByUserId(userId: string): Promise<[ServiceEntity[], number]> {
     const serviceListAndCount = await this.findAndCount({
+      select: ['id', 'name', 'domain', 'clientId'],
       where: { user: userId },
-      relations: ['theme'],
     });
     return serviceListAndCount;
   }

--- a/src/repositories/theme.ts
+++ b/src/repositories/theme.ts
@@ -1,0 +1,13 @@
+import { EntityRepository, Repository } from 'typeorm';
+
+import ThemeEntity from '../entity/theme';
+
+@EntityRepository(ThemeEntity)
+class ThemeRepository extends Repository<ThemeEntity> {
+  async findById(id: number): Promise<ThemeEntity | undefined> {
+    const theme = await this.findOne({ where: { id } });
+    return theme;
+  }
+}
+
+export default ThemeRepository;

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -28,15 +28,23 @@ class ServiceService {
     this.themeRepository = themeRepository;
   }
 
-  async getService(id: number): Promise<ServiceEntity> {
+  async getService(uid: string, id: number): Promise<ServiceEntity> {
     const service = await this.serviceRepository.findByServiceId(id);
+
     if (!service) {
       throw new ErrorResponse(commonError.notFound);
     }
+
+    if (service.user.uid !== uid) {
+      throw new ErrorResponse(commonError.forbidden);
+    }
+
     return service;
   }
 
-  async getAllServiceOfUser(uid: string): Promise<{ serviceList: ServiceEntity[]; count: number }> {
+  async getAllServiceAndCountOfUser(
+    uid: string,
+  ): Promise<{ serviceList: ServiceEntity[]; count: number }> {
     const [serviceList, count] = await this.serviceRepository.findAndCountByUserId(uid);
     return { serviceList, count };
   }

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -1,0 +1,26 @@
+import { Service } from 'typedi';
+import { InjectRepository } from 'typeorm-typedi-extensions';
+import { commonError } from '../constants/error';
+import ServiceEntity from '../entity/service';
+
+import ServiceRepository from '../repositories/service';
+import ErrorResponse from '../utils/error-response';
+
+@Service()
+class ServiceService {
+  private serviceRepository: ServiceRepository;
+
+  constructor(@InjectRepository(ServiceRepository) serviceRepository: ServiceRepository) {
+    this.serviceRepository = serviceRepository;
+  }
+
+  async getService(id: number): Promise<ServiceEntity> {
+    const service = await this.serviceRepository.findByServiceId(id);
+    if (!service) {
+      throw new ErrorResponse(commonError.badRequest);
+    }
+    return service;
+  }
+}
+
+export default ServiceService;

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -37,11 +37,8 @@ class ServiceService {
   }
 
   async getAllServiceOfUser(uid: string): Promise<{ serviceList: ServiceEntity[]; count: number }> {
-    const result = await this.serviceRepository.findByUserId(uid);
-    return {
-      serviceList: result[0],
-      count: result[1],
-    };
+    const [serviceList, count] = await this.serviceRepository.findAndCountByUserId(uid);
+    return { serviceList, count };
   }
 
   async createService(

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -64,6 +64,20 @@ class ServiceService {
     const { id, createdAt, updatedAt } = service;
     return { id, createdAt, updatedAt };
   }
+
+  async deleteService(uid: string, serviceId: number): Promise<void> {
+    const service = await this.serviceRepository.findByServiceId(serviceId);
+
+    if (!service) {
+      throw new ErrorResponse(commonError.badRequest);
+    }
+
+    if (uid !== service.user.uid) {
+      throw new ErrorResponse(commonError.forbidden);
+    }
+
+    await this.serviceRepository.deleteService(service);
+  }
 }
 
 export default ServiceService;

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -21,6 +21,14 @@ class ServiceService {
     }
     return service;
   }
+
+  async getAllServiceOfUser(uid: string): Promise<{ serviceList: ServiceEntity[]; count: number }> {
+    const result = await this.serviceRepository.findByUserId(uid);
+    return {
+      serviceList: result[0],
+      count: result[1],
+    };
+  }
 }
 
 export default ServiceService;

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -31,7 +31,7 @@ class ServiceService {
   async getService(id: number): Promise<ServiceEntity> {
     const service = await this.serviceRepository.findByServiceId(id);
     if (!service) {
-      throw new ErrorResponse(commonError.badRequest);
+      throw new ErrorResponse(commonError.notFound);
     }
     return service;
   }
@@ -66,7 +66,7 @@ class ServiceService {
     const service = await this.serviceRepository.findByServiceId(serviceId);
 
     if (!service) {
-      throw new ErrorResponse(commonError.badRequest);
+      throw new ErrorResponse(commonError.notFound);
     }
 
     if (uid !== service.user.uid) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,4 +18,3 @@ export interface RefreshCookie {
 
 export type LoginRequestBody = UserLoginInfo;
 export type CreateUserRequestBody = UserLoginInfo;
-export type RefreshRequestCookiesType = RefreshCookie;

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -1,0 +1,13 @@
+export interface ServiceBasicInfo {
+  name: string;
+  description?: string;
+  domain?: string;
+}
+
+export interface ServiceInfo extends ServiceBasicInfo {
+  clientId: string;
+  image: string;
+  question: string;
+  themeId: number;
+  userId: string;
+}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -27,7 +27,7 @@ export const getJwtAlgorithm = (algorithm: string): Algorithm => {
 };
 
 export const getAccessToken = (authorization: string | undefined): string => {
-  if (authorization && authorization.startsWith('Bearer')) {
+  if (authorization && authorization.startsWith('Bearer ')) {
     return authorization.split(' ')[1];
   }
   return '';

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -2,7 +2,7 @@ import jwt, { Algorithm, VerifyErrors } from 'jsonwebtoken';
 
 import config from '../config';
 import { REFRESH_TOKEN_COOKIE_KEY } from '../constants/auth';
-import { authError } from '../constants/error';
+import { commonError } from '../constants/error';
 import { RefreshCookie } from '../types';
 import ErrorResponse from './error-response';
 
@@ -42,7 +42,7 @@ export const getUIDFromToken = (token: string): string => {
   const decoded = jwt.decode(token);
 
   if (!decoded || typeof decoded === 'string') {
-    throw new ErrorResponse(authError.invalidToken);
+    throw new ErrorResponse(commonError.unauthorized);
   }
 
   const { uid } = decoded as { uid: string };

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -27,8 +27,10 @@ export const getJwtAlgorithm = (algorithm: string): Algorithm => {
 };
 
 export const getAccessToken = (authorization: string | undefined): string => {
-  if (!authorization) return '';
-  return authorization.split('Bearer ')[1];
+  if (authorization && authorization.startsWith('Bearer')) {
+    return authorization.split(' ')[1];
+  }
+  return '';
 };
 
 export const getRefreshToken = (cookies: RefreshCookie): string => {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,10 +1,7 @@
-import jwt, { Algorithm, VerifyErrors } from 'jsonwebtoken';
+import { Algorithm } from 'jsonwebtoken';
 
-import config from '../config';
 import { REFRESH_TOKEN_COOKIE_KEY } from '../constants/auth';
-import { commonError } from '../constants/error';
 import { RefreshCookie } from '../types';
-import ErrorResponse from './error-response';
 
 export const getJwtAlgorithm = (algorithm: string): Algorithm => {
   const jwtAlgorithms: Algorithm[] = [
@@ -36,27 +33,4 @@ export const getAccessToken = (authorization: string | undefined): string => {
 export const getRefreshToken = (cookies: RefreshCookie): string => {
   if (!cookies[REFRESH_TOKEN_COOKIE_KEY]) return '';
   return cookies[REFRESH_TOKEN_COOKIE_KEY];
-};
-
-export const getUIDFromToken = (token: string): string => {
-  const decoded = jwt.decode(token);
-
-  if (!decoded || typeof decoded === 'string') {
-    throw new ErrorResponse(commonError.unauthorized);
-  }
-
-  const { uid } = decoded as { uid: string };
-  return uid;
-};
-
-export const checkTokenExpiration = (token: string): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    jwt.verify(token, config.jwt.secret, (err: VerifyErrors | null) => {
-      if (err) {
-        if (err.name === 'TokenExpiredError') resolve(true);
-        else reject(err);
-      }
-      resolve(false);
-    });
-  });
 };

--- a/src/utils/service.ts
+++ b/src/utils/service.ts
@@ -1,8 +1,8 @@
-export const createClientId = (): string => {
-  let result = '';
-  while (result.length < 20) {
-    const randStr = Math.random().toString(36).substr(2);
-    result += randStr.substr(0, 20 - result.length);
-  }
-  return result;
-};
+/* eslint-disable no-bitwise */
+
+export const uuidv4 = (): string =>
+  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });

--- a/src/utils/service.ts
+++ b/src/utils/service.ts
@@ -1,0 +1,8 @@
+export const createClientId = (): string => {
+  let result = '';
+  while (result.length < 20) {
+    const randStr = Math.random().toString(36).substr(2);
+    result += randStr.substr(0, 20 - result.length);
+  }
+  return result;
+};

--- a/tests/helpers/jwt.test.ts
+++ b/tests/helpers/jwt.test.ts
@@ -210,4 +210,31 @@ describe('jwtHelper 모듈 테스트', () => {
       expect(jwtHelper.getRefreshExpiresInMs()).toBe(refreshExpiresinMs);
     });
   });
+
+  describe('jwtHelper.checkTokenExpiration() 함수 테스트', () => {
+    const mockedAccessTokenPayload: OwnAccessJwtPayload = { uid: 'uuid', userId: 'testID' };
+
+    it('만료된 토큰에 대해서는 true를 반환해야 합니다.', async () => {
+      const jwtHelper = new JwtHelper({
+        algorithm: 'HS256',
+        secret: 'jwt-secret',
+        accessExpiresInHour: 0,
+        refreshExpiresInHour: 0,
+      });
+
+      const accessToken = jwtHelper.generateAccessToken(mockedAccessTokenPayload);
+      const isTokenExpired = await jwtHelper.checkTokenExpiration(accessToken);
+
+      expect(isTokenExpired).toBe(true);
+    });
+
+    it('만료되지 않은 토큰에 대해서는 false를 반환해야 합니다.', async () => {
+      const jwtHelper = new JwtHelper(mockJwtOptions);
+
+      const accessToken = jwtHelper.generateAccessToken(mockedAccessTokenPayload);
+      const isTokenExpired = await jwtHelper.checkTokenExpiration(accessToken);
+
+      expect(isTokenExpired).toBe(false);
+    });
+  });
 });

--- a/tests/utils/jwt.test.ts
+++ b/tests/utils/jwt.test.ts
@@ -1,6 +1,7 @@
 import { Algorithm } from 'jsonwebtoken';
 
-import { getJwtAlgorithm } from '../../src/utils/jwt';
+import { REFRESH_TOKEN_COOKIE_KEY } from '../../src/constants/auth';
+import { getAccessToken, getJwtAlgorithm, getRefreshToken } from '../../src/utils/jwt';
 
 describe('jwt utils 테스트', () => {
   describe('getJwtAlgorithm() 함수 테스트', () => {
@@ -29,6 +30,31 @@ describe('jwt utils 테스트', () => {
       expect(getJwtAlgorithm('UnallowedAlgorithm')).toBe('none');
       expect(getJwtAlgorithm('HAHAHAHA')).toBe('none');
       expect(getJwtAlgorithm('Happy')).toBe('none');
+    });
+  });
+
+  describe('getAccessToken() 함수 테스트', () => {
+    it('올바르게 주어진 문자열에 대하여 access token을 반환해야 합니다.', () => {
+      expect(getAccessToken('Bearer access-token')).toBe('access-token');
+    });
+
+    it('잘못 주어진 문자열에 대하여 빈 문자열을 반환해야 합니다.', () => {
+      expect(getAccessToken('access-token')).toBe('');
+      expect(getAccessToken('')).toBe('');
+      expect(getAccessToken('Beareraccess-token')).toBe('');
+      expect(getAccessToken('Bear access-token')).toBe('');
+    });
+  });
+
+  describe('getRefreshToken() 함수 테스트', () => {
+    it('올바르게 주어진 문자열에 대하여 refresh token을 반환해야 합니다.', () => {
+      expect(getRefreshToken({ [REFRESH_TOKEN_COOKIE_KEY]: 'refresh-token' })).toBe(
+        'refresh-token',
+      );
+    });
+
+    it('잘못 주어진 문자열에 대하여 빈 문자열을 반환해야 합니다.', () => {
+      expect(getRefreshToken({ [REFRESH_TOKEN_COOKIE_KEY]: '' })).toBe('');
     });
   });
 });


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

서비스 CR~U~D를 구현하였습니다. (수정은 PR 단위를 고려하여 별도의 이슈로 분리하였습니다)

## 이슈 번호

- closes #9 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

- validateToken middleware 구현
- jwt util 함수 & 테스트 코드 추가
- 서비스 등록, 가져오기, 삭제 API 구현

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- postman에 등록되어 있으며 [API 문서](https://oil-pancake-0e6.notion.site/API-65eec7d612e34da8ab365f471ecc6122) 업데이트하였습니다.
- 아이디 1을 가진 default theme 데이터를 추가한 후 테스트해보아야 합니다. (`insert into theme values (1, 'default')`)
- 현재 `types/index.ts`에 기본 타입, auth, user 타입들이 있더라구요, service와 관련된 타입이 추후 길어질까봐 `service.ts`로 분리하였습니다. 이쪽 타입들을 어떻게 하는 것이 좋을까요?
- 사용자 인증 쪽 코드 한 번 검토해봐주세요!! util 함수 중 token 관련된 것은 테스트 코드를 어찌해야할지 몰라 작성하지 않았습니다.
