### PR TITLE
Projects API Route URI 개선

### DIFF
--- a/src/api/routes/projects/index.ts
+++ b/src/api/routes/projects/index.ts
@@ -19,15 +19,16 @@ import {
 const router = Router();
 
 router.post('/', validateToken, createProjectValidation, handleCreateProject);
-router.get('/id/:id', validateToken, projectIdValidation, handleGetProject);
-router.get('/user', validateToken, handleGetUserProjects);
+router.get('/', validateToken, handleGetUserProjects);
+
+router.get('/:id', validateToken, projectIdValidation, handleGetProject);
 router.patch(
-  '/id/:id',
+  '/:id',
   validateToken,
   multer().single('image'),
   updateProjectValidation,
   handleUpdateProject,
 );
-router.delete('/id/:id', validateToken, projectIdValidation, handleDeleteProject);
+router.delete('/:id', validateToken, projectIdValidation, handleDeleteProject);
 
 export default router;


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

projects api route uri에서 불필요한 prefix를 삭제했습니다.

## 이슈 번호

- closes #25 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

-  /api/projects/id/:id => /api/projects/:id로 수정
-  /api/projects/user => /api/projects 로 수정
- postman에 `Projects API - uri refactor` 폴더 만들어놨습니다.

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- #21 PR branch를 기반으로 작업해서 [요 커밋](https://github.com/telbby/telbby-backend/commit/57a37099f47a25fb3e83abd81234818dd6d957be)을 기준으로 리뷰해주시면 좋을 것 같습니다. 혹은 해당 PR 머지 후에 리뷰!
- 저번에 회의했을 때 제안했던 개선 방안에 대한 PR입니다. 그림님께서 시도하셨을 때 잘 안됐다고 하셨는 데 `/`와 `/:id`를 Route에 등록할 때 순서 때문에 그랬던 것 같습니다. `/`를 먼저 등록하고 `/:id`를 나중에 등록하니 잘 되는 것 같은 데 한번 확인해주세요!
- API 명세는 요거 merge하기로 결정되면 수정하도록 하겠습니다.